### PR TITLE
Fix out-of-bounds read in the turbulence function

### DIFF
--- a/noise_image.c
+++ b/noise_image.c
@@ -94,7 +94,7 @@ double turbulence(double x, double y, double size)
     }
 
     while(size >= 1) {
-        value += smooth_noise(x / size + offset_x[int_size], y / size + offset_y[int_size]) * size;
+        value += smooth_noise(x / size + offset_x[int_size-1], y / size + offset_y[int_size-1]) * size;
         size /= 2.0;
         int_size /= 2.0;
     }


### PR DESCRIPTION
This bug was automatically found by executing the program with [Safe Sulong](https://github.com/graalvm/sulong/blob/master/docs/SAFE-SULONG.md).